### PR TITLE
fix: let storeTheme brand properties override configTheme

### DIFF
--- a/.changeset/fix-brand-image-per-theme.md
+++ b/.changeset/fix-brand-image-per-theme.md
@@ -1,0 +1,7 @@
+---
+"@storybook-community/storybook-dark-mode": patch
+---
+
+Fix brand image not switching between light and dark themes (issue #66)
+
+`mergeThemeWithBrandConfig` now gives store theme properties priority over config theme properties, so per-mode `brandImage` and `brandTitle` set on the dark/light theme are preserved instead of being overwritten by the global config theme.

--- a/packages/storybook-dark-mode/src/_internal/utils/merge_theme_with_brand_config.stories.tsx
+++ b/packages/storybook-dark-mode/src/_internal/utils/merge_theme_with_brand_config.stories.tsx
@@ -45,6 +45,24 @@ const mockConfigTheme = {
 	brandTarget: '_blank'
 } as ThemeVars
 
+export const PerModeBrandImageIsRespected: Story = {
+	render: () => <TestComponent />,
+	play: async () => {
+		// Issue #66: brandImage should differ between dark and light themes
+		const lightStoreTheme = { base: 'light', brandImage: './logo-dark.svg' } as ThemeVars
+		const darkStoreTheme = { base: 'dark', brandImage: './logo-light.svg' } as ThemeVars
+		const configTheme = { brandTitle: 'My App' } as ThemeVars
+
+		const lightResult = mergeThemeWithBrandConfig(lightStoreTheme, configTheme)
+		const darkResult = mergeThemeWithBrandConfig(darkStoreTheme, configTheme)
+
+		expect(lightResult.brandImage).toBe('./logo-dark.svg')
+		expect(darkResult.brandImage).toBe('./logo-light.svg')
+		expect(lightResult.brandTitle).toBe('My App')
+		expect(darkResult.brandTitle).toBe('My App')
+	}
+}
+
 export const PreservesBrandPropertiesWhenSwitchingToDarkTheme: Story = {
 	render: () => <TestComponent />,
 	play: async () => {
@@ -101,19 +119,21 @@ export const HandlesPartialBrandConfiguration: Story = {
 	}
 }
 
-export const OverridesStoreThemeBrandPropertiesWithConfigTheme: Story = {
+export const StoreThemeBrandPropertiesOverrideConfigTheme: Story = {
 	render: () => <TestComponent />,
 	play: async () => {
 		const storeThemeWithBrand = {
 			...mockStoreThemes.light,
-			brandImage: 'https://store.com/old-logo.png',
-			brandTitle: 'Old Title'
+			brandImage: 'https://store.com/mode-logo.png',
+			brandTitle: 'Mode Title'
 		}
 
 		const result = mergeThemeWithBrandConfig(storeThemeWithBrand, mockConfigTheme)
 
-		expect(result.brandImage).toBe('https://example.com/my-custom-logo.png')
-		expect(result.brandTitle).toBe('My Custom App')
+		// storeTheme brand properties win — enables per-mode brandImage (fixes #66)
+		expect(result.brandImage).toBe('https://store.com/mode-logo.png')
+		expect(result.brandTitle).toBe('Mode Title')
+		// configTheme provides fallback for properties not in storeTheme
 		expect(result.brandUrl).toBe('https://example.com')
 		expect(result.brandTarget).toBe('_blank')
 	}
@@ -149,13 +169,7 @@ export const HandlesEmptyConfigThemeObject: Story = {
 		const emptyConfigTheme = {} as ThemeVars
 		const result = mergeThemeWithBrandConfig(mockStoreThemes.light, emptyConfigTheme)
 
-		expect(result).toEqual({
-			...mockStoreThemes.light,
-			brandImage: undefined,
-			brandTitle: undefined,
-			brandUrl: undefined,
-			brandTarget: undefined
-		})
+		expect(result).toEqual(mockStoreThemes.light)
 	}
 }
 

--- a/packages/storybook-dark-mode/src/_internal/utils/merge_theme_with_brand_config.ts
+++ b/packages/storybook-dark-mode/src/_internal/utils/merge_theme_with_brand_config.ts
@@ -1,10 +1,9 @@
 import type { ThemeVars } from 'storybook/theming'
 
 /**
- * Merges store theme with brand configuration from Storybook config
- * @param storeTheme - The theme from the store
- * @param configTheme - The brand configuration from Storybook config
- * @returns The merged theme with brand properties from config
+ * Merges store theme with brand configuration from Storybook config.
+ * storeTheme properties take priority so per-mode brand images/titles are preserved.
+ * configTheme acts as a fallback for any brand properties not set on the store theme.
  */
 export function mergeThemeWithBrandConfig(storeTheme: ThemeVars, configTheme: ThemeVars | undefined) {
 	if (!configTheme) {
@@ -12,10 +11,7 @@ export function mergeThemeWithBrandConfig(storeTheme: ThemeVars, configTheme: Th
 	}
 
 	return {
-		...storeTheme,
-		brandImage: configTheme.brandImage,
-		brandTitle: configTheme.brandTitle,
-		brandUrl: configTheme.brandUrl,
-		brandTarget: configTheme.brandTarget
+		...configTheme,
+		...storeTheme
 	}
 }


### PR DESCRIPTION
## Problem

`mergeThemeWithBrandConfig` always spread `configTheme` brand properties on top of `storeTheme`, so `brandImage`/`brandTitle`/`brandUrl`/`brandTarget` defined on the mode-specific theme (`darkMode.dark` / `darkMode.light`) were silently discarded.

Users who configure different brand images per mode get no effect when toggling:

```js
// This never worked — brandImage stayed the same regardless of mode
darkMode: {
  dark:  create({ base: 'dark',  brandImage: './logo-light.svg' }),
  light: create({ base: 'light', brandImage: './logo-dark.svg'  }),
}
```

## Fix

Swap the spread order so `storeTheme` wins, and `configTheme` is a fallback only:

```diff
- return {
-   ...storeTheme,
-   brandImage:   configTheme.brandImage,
-   brandTitle:   configTheme.brandTitle,
-   brandUrl:     configTheme.brandUrl,
-   brandTarget:  configTheme.brandTarget,
- }
+ return {
+   ...configTheme,
+   ...storeTheme,
+ }
```

## Stories updated

- Renamed `OverridesStoreThemeBrandPropertiesWithConfigTheme` → `StoreThemeBrandPropertiesOverrideConfigTheme` with corrected expectations
- Updated `HandlesEmptyConfigThemeObject` (empty configTheme no longer injects explicit `undefined` keys)
- Added `PerModeBrandImageIsRespected` to directly cover the scenario from #66

Fixes #66